### PR TITLE
Unlink Pleeease's modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 var pleeease = require('pleeease'),
-    postcss  = require('pleeease/node_modules/postcss'),
-    extend   = require('pleeease/node_modules/deep-extend');
+    extend   = require('deep-extend');
 
 var PleeeaseCompiler;
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "mocha test"
   },
   "dependencies": {
-    "pleeease": "^3.0.0"
+    "pleeease": "^3.0.0",
+    "deep-extend": "^0.4.1"
   },
   "devDependencies": {
     "mocha": "^2.2.5",


### PR DESCRIPTION
This is about being compatible with npm 3. With npm 2 deep-extend module could be twice in pleeease and pleeease-brunch but no breaking change.
